### PR TITLE
feat: add board invitation system with member management

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -6,15 +6,21 @@ service cloud.firestore {
     // Boards stored at /boards/{boardId}
     match /boards/{boardId} {
       // Allow read if user is owner or member
-      allow read: if request.auth != null && 
-                  (request.auth.uid == resource.data.ownerId || 
+      allow read: if request.auth != null &&
+                  (request.auth.uid == resource.data.ownerId ||
                    request.auth.uid in resource.data.members);
-      
+
       // Allow write if user is owner
       allow write: if request.auth != null && request.auth.uid == resource.data.ownerId;
-      
+
+      // Allow update if user is owner OR user is adding themselves to members (accepting invitation)
+      allow update: if request.auth != null &&
+                    (request.auth.uid == resource.data.ownerId ||
+                     (request.auth.uid in request.resource.data.members &&
+                      request.auth.uid != resource.data.ownerId));
+
       // Allow create if user sets themselves as owner
-      allow create: if request.auth != null && 
+      allow create: if request.auth != null &&
                      request.auth.uid == request.resource.data.ownerId;
       
       // Tasks stored as subcollection at /boards/{boardId}/tasks/{taskId}
@@ -43,9 +49,15 @@ service cloud.firestore {
     match /notifications/{notificationId} {
       // Users can only read their own notifications
       allow read: if request.auth != null && request.auth.uid == resource.data.userId;
-      
+
+      // Any authenticated user can create notifications (for inviting users, etc.)
+      allow create: if request.auth != null;
+
       // Users can only update their own notifications (e.g., mark as read)
       allow update: if request.auth != null && request.auth.uid == resource.data.userId;
+
+      // Users can only delete their own notifications (e.g., declining invitations)
+      allow delete: if request.auth != null && request.auth.uid == resource.data.userId;
     }
   }
 }

--- a/src/app/(protected)/board/[id]/page.tsx
+++ b/src/app/(protected)/board/[id]/page.tsx
@@ -139,8 +139,12 @@ export default function BoardPage() {
   return (
     <main className="flex-1 overflow-auto">
       <div className="container mx-auto px-0 lg:px-4 pb-8 pt-4">
-        {/* You can pass boardId to KanbanBoard if needed */}
-        <KanbanBoard />
+        <KanbanBoard
+          boardId={currentBoard.id}
+          boardName={currentBoard.name}
+          members={currentBoard.members}
+          ownerId={currentBoard.ownerId}
+        />
       </div>
     </main>
   );

--- a/src/components/BoardMembersList.tsx
+++ b/src/components/BoardMembersList.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Badge } from '@/components/ui/badge';
+import { Crown, User as UserIcon } from 'lucide-react';
+import type { User } from '@/types';
+
+interface BoardMembersListProps {
+  members: User[];
+  ownerId: string;
+  currentUserId: string;
+}
+
+export function BoardMembersList({ members, ownerId, currentUserId }: BoardMembersListProps) {
+  const getInitials = (name: string | null) => {
+    if (!name) return '??';
+    return name
+      .split(' ')
+      .map((n) => n[0])
+      .join('')
+      .toUpperCase()
+      .slice(0, 2);
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold">Members ({members.length})</h3>
+      </div>
+
+      <div className="space-y-2">
+        {members.map((member) => {
+          const isOwner = member.uid === ownerId;
+          const isCurrentUser = member.uid === currentUserId;
+
+          return (
+            <div
+              key={member.uid}
+              className="flex items-center gap-3 p-2 rounded-md hover:bg-muted/50 transition-colors"
+            >
+              <Avatar className="h-8 w-8">
+                <AvatarImage src={undefined} />
+                <AvatarFallback className="text-xs">
+                  {getInitials(member.displayName)}
+                </AvatarFallback>
+              </Avatar>
+
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2">
+                  <p className="text-sm font-medium truncate">
+                    {member.displayName || 'Unknown User'}
+                  </p>
+                  {isCurrentUser && (
+                    <Badge variant="secondary" className="text-xs">
+                      You
+                    </Badge>
+                  )}
+                </div>
+                <p className="text-xs text-muted-foreground truncate">
+                  {member.email || 'No email'}
+                </p>
+              </div>
+
+              {isOwner && (
+                <div className="flex items-center gap-1 text-amber-600 dark:text-amber-500">
+                  <Crown className="h-4 w-4" />
+                  <span className="text-xs font-medium">Owner</span>
+                </div>
+              )}
+
+              {!isOwner && (
+                <div className="flex items-center gap-1 text-muted-foreground">
+                  <UserIcon className="h-4 w-4" />
+                  <span className="text-xs">Member</span>
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/InviteModal.tsx
+++ b/src/components/InviteModal.tsx
@@ -1,0 +1,210 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Loader2, Search, X, UserPlus } from 'lucide-react';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { useUsersStore } from '@/store/useUsers';
+import { createNotification } from '@/lib/firestore';
+import { auth } from '@/lib/firebase';
+import type { User } from '@/types';
+
+interface InviteModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  boardId: string;
+  boardName: string;
+  currentMembers: string[];
+}
+
+export function InviteModal({
+  open,
+  onOpenChange,
+  boardId,
+  boardName,
+  currentMembers,
+}: InviteModalProps) {
+  const { users, initListener } = useUsersStore();
+  const [searchQuery, setSearchQuery] = useState('');
+  const [selectedUsers, setSelectedUsers] = useState<string[]>([]);
+  const [isInviting, setIsInviting] = useState(false);
+  const [searchResults, setSearchResults] = useState<User[]>([]);
+
+  useEffect(() => {
+    const unsub = initListener();
+    return () => unsub();
+  }, [initListener]);
+
+  const handleSearch = (query: string) => {
+    setSearchQuery(query);
+    if (query.trim()) {
+      const filtered = users.filter(
+        (user) =>
+          !currentMembers.includes(user.uid) &&
+          (user.displayName?.toLowerCase().includes(query.toLowerCase()) ||
+            user.email?.toLowerCase().includes(query.toLowerCase()))
+      );
+      setSearchResults(filtered);
+    } else {
+      setSearchResults([]);
+    }
+  };
+
+  const toggleUserSelection = (userId: string) => {
+    setSelectedUsers((prev) =>
+      prev.includes(userId) ? prev.filter((id) => id !== userId) : [...prev, userId]
+    );
+  };
+
+  const removeSelectedUser = (userId: string) => {
+    setSelectedUsers((prev) => prev.filter((id) => id !== userId));
+  };
+
+  const handleInvite = async () => {
+    if (selectedUsers.length === 0) return;
+
+    const inviterId = auth.currentUser?.uid;
+    if (!inviterId) {
+      console.error('User not authenticated');
+      return;
+    }
+
+    setIsInviting(true);
+    try {
+      // Create notification for each selected user
+      await Promise.all(
+        selectedUsers.map((userId) =>
+          createNotification(
+            userId,
+            'board_invitation',
+            `You've been invited to ${boardName}`,
+            `You have been invited to join the board "${boardName}". Click to accept or decline this invitation.`,
+            inviterId,
+            boardId
+          )
+        )
+      );
+
+      // Reset and close
+      setSelectedUsers([]);
+      setSearchQuery('');
+      setSearchResults([]);
+      onOpenChange(false);
+    } catch (error) {
+      console.error('Failed to invite users:', error);
+    } finally {
+      setIsInviting(false);
+    }
+  };
+
+  const getInitials = (name: string | null) => {
+    if (!name) return '??';
+    return name
+      .split(' ')
+      .map((n) => n[0])
+      .join('')
+      .toUpperCase()
+      .slice(0, 2);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[400px]">
+        <DialogHeader>
+          <DialogTitle>Invite to {boardName}</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          {/* Search Input */}
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <Input
+              value={searchQuery}
+              onChange={(e) => handleSearch(e.target.value)}
+              placeholder="Search users..."
+              className="pl-10"
+              disabled={isInviting}
+              autoFocus
+            />
+          </div>
+
+          {/* Selected Users */}
+          {selectedUsers.length > 0 && (
+            <div className="flex flex-wrap gap-2">
+              {selectedUsers.map((userId) => {
+                const user = users.find((u) => u.uid === userId);
+                if (!user) return null;
+                return (
+                  <div
+                    key={userId}
+                    className="flex items-center gap-1 bg-muted rounded-full pl-2 pr-1 py-1 text-sm"
+                  >
+                    <span>{user.displayName}</span>
+                    <button
+                      onClick={() => removeSelectedUser(userId)}
+                      className="text-muted-foreground hover:text-foreground p-0.5"
+                    >
+                      <X className="h-3 w-3" />
+                    </button>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
+          {/* Search Results */}
+          {searchResults.length > 0 && (
+            <div className="border rounded-md max-h-48 overflow-y-auto">
+              {searchResults.map((user) => {
+                const isSelected = selectedUsers.includes(user.uid);
+                return (
+                  <div
+                    key={user.uid}
+                    onClick={() => !isSelected && toggleUserSelection(user.uid)}
+                    className={`flex items-center justify-between p-2 cursor-pointer hover:bg-muted/50 ${
+                      isSelected ? 'bg-muted/50' : ''
+                    }`}
+                  >
+                    <div className="flex items-center gap-2">
+                      <Avatar className="h-6 w-6">
+                        <AvatarFallback className="text-xs">
+                          {getInitials(user.displayName)}
+                        </AvatarFallback>
+                      </Avatar>
+                      <div>
+                        <p className="text-sm font-medium">{user.displayName}</p>
+                        <p className="text-xs text-muted-foreground">{user.email}</p>
+                      </div>
+                    </div>
+                    {isSelected && <div className="w-2 h-2 bg-primary rounded-full" />}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
+          {searchQuery && searchResults.length === 0 && (
+            <p className="text-sm text-muted-foreground text-center py-4">No users found</p>
+          )}
+
+          {/* Actions */}
+          <div className="flex justify-end gap-2 pt-2">
+            <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isInviting}>
+              Cancel
+            </Button>
+            <Button
+              onClick={handleInvite}
+              disabled={selectedUsers.length === 0 || isInviting}
+              size="sm"
+            >
+              {isInviting ? <Loader2 className="h-4 w-4 animate-spin" /> : `Invite`}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/KanbanBoard.tsx
+++ b/src/components/KanbanBoard.tsx
@@ -5,11 +5,12 @@ import { useTasksStore } from '@/store/useTasks';
 import { useUsersStore } from '@/store/useUsers';
 import { usePresenceStore } from '@/store/usePresence';
 import { useNotificationsStore } from '@/store/useNotifications';
-import { Plus } from 'lucide-react';
+import { Plus, UserPlus } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import TaskCard from './TaskCard';
 import TaskDialog from './TaskDialog';
 import DeleteDialog from './DeleteDialog';
+import { InviteModal } from './InviteModal';
 import { cn } from '@/lib/utils';
 import { auth } from '@/lib/firebase';
 import type { Task, ColumnId, TaskViewer, TaskUpdate } from '@/types';
@@ -21,13 +22,21 @@ const columns = [
   { id: 'done' as const, title: 'Done', accent: 'green' as const },
 ];
 
-export default function KanbanBoard() {
+interface KanbanBoardProps {
+  boardId: string;
+  boardName: string;
+  members: string[];
+  ownerId: string;
+}
+
+export default function KanbanBoard({ boardId, boardName, members, ownerId }: KanbanBoardProps) {
   const { tasks, updateTask, deleteTask, addTask } = useTasksStore();
   const [dialogColumn, setDialogColumn] = useState<ColumnId>('todo');
   const [dialogTask, setDialogTask] = useState<Task>();
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [dialogMode, setDialogMode] = useState<'add' | 'edit'>('add');
   const [dialogOpen, setDialogOpen] = useState(false);
+  const [inviteOpen, setInviteOpen] = useState(false);
   const { presence, setTyping } = usePresenceStore();
 
   useEffect(() => {
@@ -212,6 +221,15 @@ export default function KanbanBoard() {
 
   return (
     <>
+      {/* Board Header */}
+      <div className="flex items-center justify-between mb-4 px-4">
+        <h1 className="text-2xl font-bold">{boardName}</h1>
+        <Button onClick={() => setInviteOpen(true)} variant="outline" size="sm">
+          <UserPlus className="mr-2 h-4 w-4" />
+          Invite
+        </Button>
+      </div>
+
       <DragDropContext onDragEnd={onDragEnd}>
         <div className="w-full overflow-x-auto pb-4 px-4">
           <div className="inline-flex justify-center items-start w-auto min-w-full gap-4">
@@ -246,6 +264,14 @@ export default function KanbanBoard() {
         onOpenChange={setDeleteOpen}
         title={dialogTask?.title ?? ''}
         onConfirm={confirmDelete}
+      />
+
+      <InviteModal
+        open={inviteOpen}
+        onOpenChange={setInviteOpen}
+        boardId={boardId}
+        boardName={boardName}
+        currentMembers={members}
       />
     </>
   );

--- a/src/components/NotificationDialog.tsx
+++ b/src/components/NotificationDialog.tsx
@@ -1,16 +1,41 @@
 'use client';
 
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
 import { formatDate } from '@/lib/utils';
 import type { AppNotification } from '@/types';
+import { Check, X } from 'lucide-react';
 
 interface NotificationDialogProps {
   notification: AppNotification | null;
   onOpenChange: (open: boolean) => void;
+  onAcceptInvitation?: (notificationId: string) => void;
+  onDeclineInvitation?: (notificationId: string) => void;
 }
 
-export function NotificationDialog({ notification, onOpenChange }: NotificationDialogProps) {
+export function NotificationDialog({
+  notification,
+  onOpenChange,
+  onAcceptInvitation,
+  onDeclineInvitation,
+}: NotificationDialogProps) {
   if (!notification) return null;
+
+  const isInvitation = notification.type === 'board_invitation';
+
+  const handleAccept = () => {
+    if (onAcceptInvitation) {
+      onAcceptInvitation(notification.id);
+    }
+    onOpenChange(false);
+  };
+
+  const handleDecline = () => {
+    if (onDeclineInvitation) {
+      onDeclineInvitation(notification.id);
+    }
+    onOpenChange(false);
+  };
 
   return (
     <Dialog open={!!notification} onOpenChange={onOpenChange}>
@@ -29,6 +54,20 @@ export function NotificationDialog({ notification, onOpenChange }: NotificationD
             <p>Date: {formatDate(notification.createdAt)}</p>
             {notification.actorId && <p>From: User ID {notification.actorId}</p>}
           </div>
+
+          {/* Invitation Actions */}
+          {isInvitation && (
+            <div className="flex gap-2 pt-2">
+              <Button onClick={handleAccept} className="flex-1">
+                <Check className="mr-2 h-4 w-4" />
+                Accept
+              </Button>
+              <Button onClick={handleDecline} variant="outline" className="flex-1">
+                <X className="mr-2 h-4 w-4" />
+                Decline
+              </Button>
+            </div>
+          )}
         </div>
       </DialogContent>
     </Dialog>

--- a/src/components/NotificationIcon.tsx
+++ b/src/components/NotificationIcon.tsx
@@ -15,6 +15,8 @@ import {
 import { useState, useEffect } from 'react';
 import { useNotificationsStore } from '@/store/useNotifications';
 import { NotificationDialog } from './NotificationDialog';
+import { acceptBoardInvitation, declineBoardInvitation } from '@/lib/firestore';
+import { auth } from '@/lib/firebase';
 import type { AppNotification } from '@/types';
 
 export default function NotificationIcon() {
@@ -42,6 +44,31 @@ export default function NotificationIcon() {
   const handleDialogOpenChange = (open: boolean) => {
     if (!open) {
       setSelectedNotification(null);
+    }
+  };
+
+  const handleAcceptInvitation = async (notificationId: string) => {
+    const notification = notifications.find((n) => n.id === notificationId);
+    if (!notification || !notification.boardId) return;
+
+    const userId = auth.currentUser?.uid;
+    if (!userId) return;
+
+    try {
+      await acceptBoardInvitation(notificationId, userId, notification.boardId);
+    } catch (error) {
+      console.error('Failed to accept invitation:', error);
+    }
+  };
+
+  const handleDeclineInvitation = async (notificationId: string) => {
+    const userId = auth.currentUser?.uid;
+    if (!userId) return;
+
+    try {
+      await declineBoardInvitation(notificationId, userId);
+    } catch (error) {
+      console.error('Failed to decline invitation:', error);
     }
   };
 
@@ -155,6 +182,8 @@ export default function NotificationIcon() {
       <NotificationDialog
         notification={selectedNotification}
         onOpenChange={handleDialogOpenChange}
+        onAcceptInvitation={handleAcceptInvitation}
+        onDeclineInvitation={handleDeclineInvitation}
       />
     </>
   );

--- a/src/lib/firestore.ts
+++ b/src/lib/firestore.ts
@@ -7,11 +7,13 @@ import {
   deleteDoc,
   doc,
   setDoc,
+  getDoc,
   onSnapshot,
   query,
   orderBy,
   serverTimestamp,
   where,
+  arrayUnion,
 } from 'firebase/firestore';
 import type { User, Task, Board, AppNotification, ColumnId } from '@/types';
 
@@ -108,6 +110,29 @@ export const createUserInFirestore = async (user: User) => {
   );
 };
 
+// Create Notification
+export const createNotification = async (
+  userId: string,
+  type: string,
+  title: string,
+  message: string,
+  actorId?: string,
+  boardId?: string
+) => {
+  const notificationsCol = collection(db, 'notifications');
+  const docRef = await addDoc(notificationsCol, {
+    userId,
+    type,
+    title,
+    message,
+    actorId,
+    boardId,
+    read: false,
+    createdAt: serverTimestamp(),
+  });
+  return docRef.id;
+};
+
 // Update notification read status
 export const markNotificationAsRead = async (notificationId: string) => {
   const notificationRef = doc(db, 'notifications', notificationId);
@@ -115,6 +140,89 @@ export const markNotificationAsRead = async (notificationId: string) => {
     read: true,
     updatedAt: serverTimestamp(),
   });
+};
+
+// Accept Board Invitation
+export const acceptBoardInvitation = async (
+  notificationId: string,
+  userId: string,
+  boardId: string
+) => {
+  const boardRef = doc(db, 'boards', boardId);
+  const notificationRef = doc(db, 'notifications', notificationId);
+  const userRef = doc(db, 'users', userId);
+
+  // Get notification data to find inviter
+  const notificationSnap = await getDoc(notificationRef);
+  const notificationData = notificationSnap.data();
+  const inviterId = notificationData?.actorId;
+
+  // Get user data to get display name
+  const userSnap = await getDoc(userRef);
+  const userData = userSnap.data();
+  const userDisplayName = userData?.displayName || 'A user';
+
+  // Add user to board members
+  await updateDoc(boardRef, {
+    members: arrayUnion(userId),
+    updatedAt: serverTimestamp(),
+  });
+
+  // Mark notification as read
+  await markNotificationAsRead(notificationId);
+
+  // Notify inviter that invitation was accepted
+  if (inviterId) {
+    const boardSnap = await getDoc(boardRef);
+    const boardData = boardSnap.data();
+    const boardName = boardData?.name || 'a board';
+
+    await createNotification(
+      inviterId,
+      'invitation_accepted',
+      'Invitation accepted',
+      `${userDisplayName} has accepted your invitation to join "${boardName}".`,
+      userId,
+      boardId
+    );
+  }
+};
+
+// Decline Board Invitation
+export const declineBoardInvitation = async (notificationId: string, userId: string) => {
+  const notificationRef = doc(db, 'notifications', notificationId);
+  const userRef = doc(db, 'users', userId);
+
+  // Get notification data to find inviter
+  const notificationSnap = await getDoc(notificationRef);
+  const notificationData = notificationSnap.data();
+  const inviterId = notificationData?.actorId;
+  const boardId = notificationData?.boardId;
+
+  // Get user data to get display name
+  const userSnap = await getDoc(userRef);
+  const userData = userSnap.data();
+  const userDisplayName = userData?.displayName || 'A user';
+
+  // Delete the notification
+  await deleteDoc(notificationRef);
+
+  // Notify inviter that invitation was declined
+  if (inviterId && boardId) {
+    const boardRef = doc(db, 'boards', boardId);
+    const boardSnap = await getDoc(boardRef);
+    const boardData = boardSnap.data();
+    const boardName = boardData?.name || 'a board';
+
+    await createNotification(
+      inviterId,
+      'invitation_declined',
+      'Invitation declined',
+      `${userDisplayName} has declined your invitation to join "${boardName}".`,
+      userId,
+      boardId
+    );
+  }
 };
 
 // Get Notifications (Real-time listener)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -86,7 +86,10 @@ type NotificationType =
   | 'user_editing_task'
   | 'task_completed'
   | 'board_access_granted'
-  | 'board_access_revoked';
+  | 'board_access_revoked'
+  | 'board_invitation'
+  | 'invitation_accepted'
+  | 'invitation_declined';
 
 export interface AppNotification {
   id: string;
@@ -95,6 +98,7 @@ export interface AppNotification {
   title: string; // Short notification title
   message: string; // Detailed message
   actorId?: string; // Who triggered the notification
+  boardId?: string; // Related board ID (for invitations)
   read: boolean; // Read status
   createdAt: TimestampLike;
 }


### PR DESCRIPTION
Add comprehensive board invitation functionality allowing owners to invite users and manage board members. Implement invitation notifications with accept/decline actions, update Firestore security rules to support invitation workflows, and create UI components for member management and user search.