### PR TITLE
feat: implement role-based access control system for board members

### DIFF
--- a/src/components/BoardMembersList.tsx
+++ b/src/components/BoardMembersList.tsx
@@ -2,16 +2,22 @@
 
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
-import { Crown } from 'lucide-react';
-import type { User } from '@/types';
+import { Crown, Shield, Eye } from 'lucide-react';
+import type { User, Role } from '@/types';
 
 interface BoardMembersListProps {
-  members: User[];
+  members: Record<string, Role>;
+  users: User[];
   ownerId: string;
   currentUserId: string;
 }
 
-export function BoardMembersList({ members, ownerId, currentUserId }: BoardMembersListProps) {
+export function BoardMembersList({
+  members,
+  users,
+  ownerId,
+  currentUserId,
+}: BoardMembersListProps) {
   const getInitials = (name: string | null) => {
     if (!name) return '??';
     return name
@@ -22,35 +28,73 @@ export function BoardMembersList({ members, ownerId, currentUserId }: BoardMembe
       .slice(0, 2);
   };
 
+  const getRoleBadge = (userId: string, role: Role) => {
+    const isOwner = userId === ownerId;
+
+    if (isOwner) {
+      return (
+        <div className="flex items-center gap-1.5 text-amber-600 dark:text-amber-500">
+          <Crown className="h-3.5 w-3.5" />
+          <span className="text-xs font-medium">Owner</span>
+        </div>
+      );
+    }
+
+    switch (role) {
+      case 'admin':
+        return (
+          <Badge variant="destructive" className="text-xs">
+            Admin
+          </Badge>
+        );
+      case 'editor':
+        return (
+          <div className="flex items-center gap-1.5 text-blue-600 dark:text-blue-500">
+            <Shield className="h-3.5 w-3.5" />
+            <span className="text-xs font-medium">Editor</span>
+          </div>
+        );
+      case 'viewer':
+        return (
+          <div className="flex items-center gap-1.5 text-muted-foreground">
+            <Eye className="h-3.5 w-3.5" />
+            <span className="text-xs font-medium">Viewer</span>
+          </div>
+        );
+      default:
+        return null;
+    }
+  };
+
   return (
     <div className="space-y-3">
       <div className="flex items-center justify-between">
         <h3 className="text-sm font-semibold">Board Members</h3>
         <Badge variant="outline" className="text-xs">
-          {members.length}
+          {Object.keys(members).length}
         </Badge>
       </div>
 
       <div className="space-y-1">
-        {members.map((member) => {
-          const isOwner = member.uid === ownerId;
-          const isCurrentUser = member.uid === currentUserId;
+        {Object.entries(members).map(([userId, role]) => {
+          const user = users.find((u) => u.uid === userId);
+          const isCurrentUser = userId === currentUserId;
 
           return (
             <div
-              key={member.uid}
+              key={userId}
               className="flex items-center gap-3 px-2 py-2 rounded-md hover:bg-muted/50 transition-colors"
             >
               <Avatar className="h-8 w-8 border">
                 <AvatarFallback className="text-xs bg-primary/10 text-primary">
-                  {getInitials(member.displayName)}
+                  {getInitials(user?.displayName || null)}
                 </AvatarFallback>
               </Avatar>
 
               <div className="flex-1 min-w-0">
                 <div className="flex items-center gap-2">
                   <p className="text-sm font-medium truncate">
-                    {member.displayName || 'Unknown User'}
+                    {user?.displayName || 'Unknown User'}
                   </p>
                   {isCurrentUser && (
                     <Badge variant="secondary" className="text-xs px-1.5 py-0">
@@ -58,15 +102,10 @@ export function BoardMembersList({ members, ownerId, currentUserId }: BoardMembe
                     </Badge>
                   )}
                 </div>
-                <p className="text-xs text-muted-foreground truncate">{member.email || ''}</p>
+                <p className="text-xs text-muted-foreground truncate">{user?.email || ''}</p>
               </div>
 
-              {isOwner && (
-                <div className="flex items-center gap-1.5 text-amber-600 dark:text-amber-500">
-                  <Crown className="h-3.5 w-3.5" />
-                  <span className="text-xs font-medium">Owner</span>
-                </div>
-              )}
+              {getRoleBadge(userId, role)}
             </div>
           );
         })}

--- a/src/components/CreateBoardModal.tsx
+++ b/src/components/CreateBoardModal.tsx
@@ -49,7 +49,7 @@ export function CreateBoardModal({ open, onOpenChange }: CreateBoardModalProps) 
         description: description.trim() || undefined,
         color: selectedColor,
         ownerId: '', // Will be set by the hook
-        members: [], // Will be set by the hook
+        members: {}, // Will be set by the hook
       });
 
       // Reset form

--- a/src/components/InviteModal.tsx
+++ b/src/components/InviteModal.tsx
@@ -9,14 +9,14 @@ import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { useUsersStore } from '@/store/useUsers';
 import { createNotification } from '@/lib/firestore';
 import { auth } from '@/lib/firebase';
-import type { User } from '@/types';
+import type { User, Role } from '@/types';
 
 interface InviteModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   boardId: string;
   boardName: string;
-  currentMembers: string[];
+  currentMembers: Record<string, Role>;
 }
 
 export function InviteModal({
@@ -42,7 +42,7 @@ export function InviteModal({
     if (query.trim()) {
       const filtered = users.filter(
         (user) =>
-          !currentMembers.includes(user.uid) &&
+          !(user.uid in currentMembers) &&
           (user.displayName?.toLowerCase().includes(query.toLowerCase()) ||
             user.email?.toLowerCase().includes(query.toLowerCase()))
       );

--- a/src/components/KanbanBoard.tsx
+++ b/src/components/KanbanBoard.tsx
@@ -19,7 +19,7 @@ import { InviteModal } from './InviteModal';
 import { BoardMembersList } from './BoardMembersList';
 import { cn } from '@/lib/utils';
 import { auth } from '@/lib/firebase';
-import type { Task, ColumnId, TaskViewer, TaskUpdate } from '@/types';
+import type { Task, ColumnId, TaskViewer, TaskUpdate, Role } from '@/types';
 import React from 'react';
 
 const columns = [
@@ -31,7 +31,7 @@ const columns = [
 interface KanbanBoardProps {
   boardId: string;
   boardName: string;
-  members: string[];
+  members: Record<string, Role>;
   ownerId: string;
 }
 
@@ -49,7 +49,7 @@ export default function KanbanBoard({ boardId, boardName, members, ownerId }: Ka
   const currentUserId = auth.currentUser?.uid;
 
   // Get member user objects
-  const memberUsers = users.filter((user) => members.includes(user.uid));
+  const memberUsers = users.filter((user) => user.uid in members);
 
   useEffect(() => {
     // Only set typing status if we have a valid task ID
@@ -247,7 +247,8 @@ export default function KanbanBoard({ boardId, boardName, members, ownerId }: Ka
             <DropdownMenuContent align="end" className="w-80 p-0">
               <div className="p-4">
                 <BoardMembersList
-                  members={memberUsers}
+                  members={members}
+                  users={users}
                   ownerId={ownerId}
                   currentUserId={currentUserId || ''}
                 />

--- a/src/components/PresenceAvatars.tsx
+++ b/src/components/PresenceAvatars.tsx
@@ -25,7 +25,7 @@ export default function PresenceAvatars() {
           // Exclude current user
           if (id === currentUser?.uid) return false;
           // Filter by board members if on a board page
-          if (boardMembers && !boardMembers.includes(id)) return false;
+          if (boardMembers && !(id in boardMembers)) return false;
           return true;
         })
         .map(([id, userData]) => ({

--- a/src/lib/firestore.ts
+++ b/src/lib/firestore.ts
@@ -15,7 +15,7 @@ import {
   where,
   arrayUnion,
 } from 'firebase/firestore';
-import type { User, Task, Board, AppNotification, ColumnId } from '@/types';
+import type { User, Task, Board, AppNotification, ColumnId, Role } from '@/types';
 
 // COLLECTION REFERENCE
 const boardsCol = collection(db, 'boards');
@@ -162,9 +162,14 @@ export const acceptBoardInvitation = async (
   const userData = userSnap.data();
   const userDisplayName = userData?.displayName || 'A user';
 
-  // Add user to board members
+  // Get current board data to add member with viewer role
+  const boardSnap = await getDoc(boardRef);
+  const boardData = boardSnap.data();
+  const currentMembers = boardData?.members || {};
+
+  // Add user to board members with viewer role
   await updateDoc(boardRef, {
-    members: arrayUnion(userId),
+    members: { ...currentMembers, [userId]: 'viewer' as Role },
     updatedAt: serverTimestamp(),
   });
 
@@ -173,8 +178,6 @@ export const acceptBoardInvitation = async (
 
   // Notify inviter that invitation was accepted
   if (inviterId) {
-    const boardSnap = await getDoc(boardRef);
-    const boardData = boardSnap.data();
     const boardName = boardData?.name || 'a board';
 
     await createNotification(
@@ -253,6 +256,66 @@ export const addBoard = async (values: Omit<Board, 'id' | 'createdAt' | 'updated
   return docRef.id;
 };
 
+// Helper: Add member to board with specific role
+export const addBoardMember = async (boardId: string, userId: string, role: Role) => {
+  const boardRef = doc(db, 'boards', boardId);
+  const boardSnap = await getDoc(boardRef);
+  const boardData = boardSnap.data();
+  const currentMembers = boardData?.members || {};
+
+  // Check if user is already a member
+  if (userId in currentMembers) {
+    throw new Error('User is already a member of this board');
+  }
+
+  await updateDoc(boardRef, {
+    members: { ...currentMembers, [userId]: role },
+    updatedAt: serverTimestamp(),
+  });
+};
+
+// Helper: Remove member from board
+export const removeBoardMember = async (boardId: string, userId: string) => {
+  const boardRef = doc(db, 'boards', boardId);
+  const boardSnap = await getDoc(boardRef);
+  const boardData = boardSnap.data();
+  const currentMembers = boardData?.members || {};
+
+  const { [userId]: removed, ...remainingMembers } = currentMembers;
+
+  await updateDoc(boardRef, {
+    members: remainingMembers,
+    updatedAt: serverTimestamp(),
+  });
+};
+
+// Helper: Update member role
+export const updateBoardMemberRole = async (boardId: string, userId: string, newRole: Role) => {
+  const boardRef = doc(db, 'boards', boardId);
+  const boardSnap = await getDoc(boardRef);
+  const boardData = boardSnap.data();
+  const currentMembers = boardData?.members || {};
+
+  if (!(userId in currentMembers)) {
+    throw new Error('User is not a member of this board');
+  }
+
+  await updateDoc(boardRef, {
+    members: { ...currentMembers, [userId]: newRole },
+    updatedAt: serverTimestamp(),
+  });
+};
+
+// Helper: Get user's role on a board
+export const getUserBoardRole = async (boardId: string, userId: string): Promise<Role | null> => {
+  const boardRef = doc(db, 'boards', boardId);
+  const boardSnap = await getDoc(boardRef);
+  const boardData = boardSnap.data();
+  const members = boardData?.members || {};
+
+  return members[userId] || null;
+};
+
 // Update Board
 export const updateBoard = async (boardId: string, updates: Partial<Omit<Board, 'id'>>) => {
   const boardRef = doc(db, 'boards', boardId);
@@ -283,17 +346,19 @@ export const listenToBoards = (callback: (boards: Board[]) => void) => {
 
 // Listen to user's boards (either as owner or member)
 export const listenToUserBoards = (userId: string, callback: (boards: Board[]) => void) => {
-  const q = query(
-    boardsCol,
-    where('members', 'array-contains', userId),
-    orderBy('createdAt', 'desc')
-  );
+  const q = query(boardsCol, orderBy('createdAt', 'desc'));
   return onSnapshot(q, (snapshot) => {
-    const boards = snapshot.docs.map((doc) => {
+    const allBoards = snapshot.docs.map((doc) => {
       const createdAt = parseTimestamp(doc.data()?.createdAt) || new Date();
       const updatedAt = parseTimestamp(doc.data()?.updatedAt) || new Date();
       return { id: doc.id, ...doc.data(), createdAt, updatedAt } as Board;
     });
-    callback(boards);
+
+    // Filter boards where user is owner or a member
+    const userBoards = allBoards.filter(
+      (board) => board.ownerId === userId || userId in board.members
+    );
+
+    callback(userBoards);
   });
 };

--- a/src/store/useBoards.ts
+++ b/src/store/useBoards.ts
@@ -8,7 +8,7 @@ import {
   deleteBoard as deleteBoardFromFirestore,
   listenToUserBoards,
 } from '@/lib/firestore';
-import type { Board, BoardsState } from '@/types';
+import type { Board, BoardsState, Role } from '@/types';
 
 export function useBoards(): BoardsState {
   const [boards, setBoards] = useState<Board[]>([]);
@@ -41,7 +41,10 @@ export function useBoards(): BoardsState {
         const boardId = await addBoardToFirestore({
           ...data,
           ownerId: user.uid,
-          members: data.members?.length ? data.members : [user.uid],
+          members:
+            data.members && Object.keys(data.members).length > 0
+              ? data.members
+              : { [user.uid]: 'admin' as Role },
         });
         return boardId;
       } catch (error) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,5 @@
+export type Role = 'admin' | 'editor' | 'viewer';
+
 export interface User {
   uid: string;
   email: string | null;
@@ -121,7 +123,7 @@ export interface Board {
   createdAt: TimestampLike;
   updatedAt: TimestampLike;
   ownerId: string;
-  members: string[];
+  members: Record<string, Role>; // Map of userId -> role
 }
 
 export interface BoardsState {


### PR DESCRIPTION
Add role-based permissions (admin, editor, viewer) to board member management. Update board members structure from array to Record mapping user IDs to roles. Add role badges with icons in member list UI, implement role management functions in Firestore, and update board invitation flow to assign viewer role by default.