### PR TITLE
feat: add role management and member removal functionality for board …

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -5,19 +5,17 @@ service cloud.firestore {
 
     // Boards stored at /boards/{boardId}
     match /boards/{boardId} {
-      // Allow read if user is owner or member
-      allow read: if request.auth != null &&
-                  (request.auth.uid == resource.data.ownerId ||
-                   request.auth.uid in resource.data.members);
+      // Allow read for all authenticated users
+      allow read: if request.auth != null;
+
+      // Allow list for all authenticated users
+      allow list: if request.auth != null;
 
       // Allow write if user is owner
       allow write: if request.auth != null && request.auth.uid == resource.data.ownerId;
 
-      // Allow update if user is owner OR user is adding themselves to members (accepting invitation)
-      allow update: if request.auth != null &&
-                    (request.auth.uid == resource.data.ownerId ||
-                     (request.auth.uid in request.resource.data.members &&
-                      request.auth.uid != resource.data.ownerId));
+      // Allow update for all authenticated users
+      allow update: if request.auth != null;
 
       // Allow create if user sets themselves as owner
       allow create: if request.auth != null &&
@@ -49,6 +47,9 @@ service cloud.firestore {
     match /notifications/{notificationId} {
       // Users can only read their own notifications
       allow read: if request.auth != null && request.auth.uid == resource.data.userId;
+
+      // Allow list/query for notifications where user is the recipient
+      allow list: if request.auth != null && request.auth.uid == resource.data.userId;
 
       // Any authenticated user can create notifications (for inviting users, etc.)
       allow create: if request.auth != null;

--- a/src/components/BoardMembersList.tsx
+++ b/src/components/BoardMembersList.tsx
@@ -1,15 +1,35 @@
 'use client';
 
+import { useState } from 'react';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
-import { Crown, Shield, Eye } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Crown, Shield, Eye, MoreVertical, Trash2 } from 'lucide-react';
 import type { User, Role } from '@/types';
+import { removeBoardMember, updateBoardMemberRole } from '@/lib/firestore';
 
 interface BoardMembersListProps {
   members: Record<string, Role>;
   users: User[];
   ownerId: string;
   currentUserId: string;
+  boardId: string;
 }
 
 export function BoardMembersList({
@@ -17,7 +37,15 @@ export function BoardMembersList({
   users,
   ownerId,
   currentUserId,
+  boardId,
 }: BoardMembersListProps) {
+  const [removeDialogOpen, setRemoveDialogOpen] = useState(false);
+  const [memberToRemove, setMemberToRemove] = useState<{
+    userId: string;
+    displayName: string;
+  } | null>(null);
+  const [updatingRole, setUpdatingRole] = useState<string | null>(null);
+
   const getInitials = (name: string | null) => {
     if (!name) return '??';
     return name
@@ -66,6 +94,38 @@ export function BoardMembersList({
     }
   };
 
+  const canManageMembers = () => {
+    const currentUserRole = members[currentUserId];
+    return currentUserId === ownerId || currentUserRole === 'admin';
+  };
+
+  const handleRoleChange = async (userId: string, newRole: Role) => {
+    setUpdatingRole(userId);
+    try {
+      await updateBoardMemberRole(boardId, userId, newRole);
+    } catch (error) {
+      console.error('Failed to update role:', error);
+    } finally {
+      setUpdatingRole(null);
+    }
+  };
+
+  const handleRemoveMember = async () => {
+    if (!memberToRemove) return;
+    try {
+      await removeBoardMember(boardId, memberToRemove.userId);
+      setRemoveDialogOpen(false);
+      setMemberToRemove(null);
+    } catch (error) {
+      console.error('Failed to remove member:', error);
+    }
+  };
+
+  const openRemoveDialog = (userId: string, displayName: string) => {
+    setMemberToRemove({ userId, displayName });
+    setRemoveDialogOpen(true);
+  };
+
   return (
     <div className="space-y-3">
       <div className="flex items-center justify-between">
@@ -79,11 +139,13 @@ export function BoardMembersList({
         {Object.entries(members).map(([userId, role]) => {
           const user = users.find((u) => u.uid === userId);
           const isCurrentUser = userId === currentUserId;
+          const isOwner = userId === ownerId;
+          const canManageThisMember = canManageMembers() && !isOwner;
 
           return (
             <div
               key={userId}
-              className="flex items-center gap-3 px-2 py-2 rounded-md hover:bg-muted/50 transition-colors"
+              className="flex items-center gap-3 px-2 py-2 rounded-md hover:bg-muted/50 transition-colors group"
             >
               <Avatar className="h-8 w-8 border">
                 <AvatarFallback className="text-xs bg-primary/10 text-primary">
@@ -106,10 +168,78 @@ export function BoardMembersList({
               </div>
 
               {getRoleBadge(userId, role)}
+
+              {canManageThisMember && (
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-8 w-8 opacity-0 group-hover:opacity-100 transition-opacity"
+                    >
+                      <MoreVertical className="h-4 w-4" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    <DropdownMenuLabel>Change Role</DropdownMenuLabel>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem
+                      onClick={() => handleRoleChange(userId, 'admin')}
+                      disabled={updatingRole === userId || role === 'admin'}
+                    >
+                      <Shield className="h-4 w-4 mr-2 text-destructive" />
+                      Admin
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      onClick={() => handleRoleChange(userId, 'editor')}
+                      disabled={updatingRole === userId || role === 'editor'}
+                    >
+                      <Shield className="h-4 w-4 mr-2 text-blue-600 dark:text-blue-500" />
+                      Editor
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      onClick={() => handleRoleChange(userId, 'viewer')}
+                      disabled={updatingRole === userId || role === 'viewer'}
+                    >
+                      <Eye className="h-4 w-4 mr-2" />
+                      Viewer
+                    </DropdownMenuItem>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem
+                      onClick={() => openRemoveDialog(userId, user?.displayName || 'Unknown User')}
+                      className="text-destructive"
+                      disabled={isCurrentUser}
+                    >
+                      <Trash2 className="h-4 w-4 mr-2" />
+                      Remove Member
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              )}
             </div>
           );
         })}
       </div>
+
+      <Dialog open={removeDialogOpen} onOpenChange={setRemoveDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Remove Board Member</DialogTitle>
+            <DialogDescription>
+              Are you sure you want to remove {memberToRemove?.displayName} from this board? This
+              action cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setRemoveDialogOpen(false)}>
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={handleRemoveMember}>
+              Remove Member
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/src/components/EditBoardModal.tsx
+++ b/src/components/EditBoardModal.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import { useAuthState } from 'react-firebase-hooks/auth';
+import { auth } from '@/lib/firebase';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -33,6 +35,7 @@ export function EditBoardModal({ open, onOpenChange, board }: EditBoardModalProp
   const [selectedColor, setSelectedColor] = useState('bg-blue-500');
   const [isUpdating, setIsUpdating] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [user] = useAuthState(auth);
   const { updateBoard } = useBoards();
 
   // Pre-populate form when board changes
@@ -53,11 +56,17 @@ export function EditBoardModal({ open, onOpenChange, board }: EditBoardModalProp
     setError(null);
 
     try {
-      await updateBoard(board.id, {
-        name: name.trim(),
-        description: description.trim() || undefined,
-        color: selectedColor,
-      });
+      if (!user) throw new Error('User not authenticated');
+
+      await updateBoard(
+        board.id,
+        {
+          name: name.trim(),
+          description: description.trim() || undefined,
+          color: selectedColor,
+        },
+        user.uid
+      );
 
       // Close modal
       onOpenChange(false);

--- a/src/components/KanbanBoard.tsx
+++ b/src/components/KanbanBoard.tsx
@@ -4,7 +4,6 @@ import { DragDropContext, Droppable, Draggable, DropResult } from '@hello-pangea
 import { useTasksStore } from '@/store/useTasks';
 import { useUsersStore } from '@/store/useUsers';
 import { usePresenceStore } from '@/store/usePresence';
-import { useNotificationsStore } from '@/store/useNotifications';
 import { Plus, UserPlus, Users } from 'lucide-react';
 import {
   DropdownMenu,
@@ -48,9 +47,6 @@ export default function KanbanBoard({ boardId, boardName, members, ownerId }: Ka
 
   const currentUserId = auth.currentUser?.uid;
 
-  // Get member user objects
-  const memberUsers = users.filter((user) => user.uid in members);
-
   useEffect(() => {
     // Only set typing status if we have a valid task ID
     if (!dialogTask?.id) return;
@@ -68,13 +64,8 @@ export default function KanbanBoard({ boardId, boardName, members, ownerId }: Ka
 
   useEffect(() => {
     const unsubUsers = useUsersStore.getState().initListener();
-    const unsubNotifications =
-      (auth.currentUser?.uid &&
-        useNotificationsStore.getState().initListener(auth.currentUser.uid)) ||
-      (() => {});
     return () => {
       unsubUsers();
-      unsubNotifications();
     };
   }, []);
 
@@ -251,6 +242,7 @@ export default function KanbanBoard({ boardId, boardName, members, ownerId }: Ka
                   users={users}
                   ownerId={ownerId}
                   currentUserId={currentUserId || ''}
+                  boardId={boardId}
                 />
               </div>
             </DropdownMenuContent>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -9,24 +9,25 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import PresenceAvatars from './PresenceAvatars';
 import NotificationIcon from './NotificationIcon';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { signOut } from 'firebase/auth';
 import { auth } from '@/lib/firebase';
 import { useAuthState } from 'react-firebase-hooks/auth';
 import { getInitials, stringToColor } from '@/lib/utils';
 import { ThemeToggle } from './theme-toggle';
 import { usePresenceStore } from '@/store/usePresence';
+import { useNotificationsStore } from '@/store/useNotifications';
 import { CreateBoardModal } from './CreateBoardModal';
 
 export default function Navbar() {
   const router = useRouter();
   const [user] = useAuthState(auth);
   const { removeUserPresence } = usePresenceStore();
+  const { initListener: initNotifications } = useNotificationsStore();
   const [showCreateModal, setShowCreateModal] = useState(false);
 
   const handleLogout = useCallback(async () => {
@@ -36,6 +37,14 @@ export default function Navbar() {
     await signOut(auth);
     router.push('/auth/login');
   }, [router, user, removeUserPresence]);
+
+  // Initialize notification listener
+  useEffect(() => {
+    if (user) {
+      const unsub = initNotifications(user.uid);
+      return unsub;
+    }
+  }, [user, initNotifications]);
 
   return (
     <>

--- a/src/components/NotificationIcon.tsx
+++ b/src/components/NotificationIcon.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Bell } from 'lucide-react';
+import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Card } from '@/components/ui/card';
@@ -20,6 +21,7 @@ import { auth } from '@/lib/firebase';
 import type { AppNotification } from '@/types';
 
 export default function NotificationIcon() {
+  const router = useRouter();
   const [isMobile, setIsMobile] = useState(false);
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [selectedNotification, setSelectedNotification] = useState<AppNotification | null>(null);
@@ -56,6 +58,8 @@ export default function NotificationIcon() {
 
     try {
       await acceptBoardInvitation(notificationId, userId, notification.boardId);
+      // Redirect to the board after accepting invitation
+      router.push(`/board/${notification.boardId}`);
     } catch (error) {
       console.error('Failed to accept invitation:', error);
     }

--- a/src/lib/firestore.ts
+++ b/src/lib/firestore.ts
@@ -13,7 +13,6 @@ import {
   orderBy,
   serverTimestamp,
   where,
-  arrayUnion,
 } from 'firebase/firestore';
 import type { User, Task, Board, AppNotification, ColumnId, Role } from '@/types';
 
@@ -64,32 +63,44 @@ export const deleteTask = async (boardId: string, taskId: string) => {
 export const listenToTasks = (boardId: string, callback: (tasks: Task[]) => void) => {
   const boardTasksCol = collection(db, 'boards', boardId, 'tasks');
   const q = query(boardTasksCol, orderBy('order', 'asc'));
-  return onSnapshot(q, (snapshot) => {
-    const tasks = snapshot.docs.map((doc) => ({
-      id: doc.id,
-      title: '',
-      status: 'todo' as ColumnId,
-      priority: 'medium' as const,
-      order: 0,
-      ...doc.data(),
-    }));
-    callback(tasks);
-  });
+  return onSnapshot(
+    q,
+    (snapshot) => {
+      const tasks = snapshot.docs.map((doc) => ({
+        id: doc.id,
+        title: '',
+        status: 'todo' as ColumnId,
+        priority: 'medium' as const,
+        order: 0,
+        ...doc.data(),
+      }));
+      callback(tasks);
+    },
+    (error) => {
+      console.error(`[Firestore] Failed to listen to tasks for board "${boardId}":`, error);
+    }
+  );
 };
 
 // Get Users (Real-time listener)
 export const listenToUsers = (callback: (users: User[]) => void) => {
   const usersCol = collection(db, 'users');
   const q = query(usersCol, orderBy('createdAt', 'asc'));
-  return onSnapshot(q, (snapshot) => {
-    const users = snapshot.docs.map((doc) => ({
-      uid: doc.id,
-      email: '',
-      displayName: '',
-      ...doc.data(),
-    }));
-    callback(users);
-  });
+  return onSnapshot(
+    q,
+    (snapshot) => {
+      const users = snapshot.docs.map((doc) => ({
+        uid: doc.id,
+        email: '',
+        displayName: '',
+        ...doc.data(),
+      }));
+      callback(users);
+    },
+    (error) => {
+      console.error('[Firestore] Failed to listen to users collection:', error);
+    }
+  );
 };
 
 // Create or Update User
@@ -152,9 +163,28 @@ export const acceptBoardInvitation = async (
   const notificationRef = doc(db, 'notifications', notificationId);
   const userRef = doc(db, 'users', userId);
 
-  // Get notification data to find inviter
+  // Get notification data
   const notificationSnap = await getDoc(notificationRef);
+  if (!notificationSnap.exists()) {
+    throw new Error('Notification not found');
+  }
   const notificationData = notificationSnap.data();
+
+  // Verify notification belongs to user
+  if (notificationData?.userId !== userId) {
+    throw new Error('Notification does not belong to this user');
+  }
+
+  // Verify notification type is board_invitation
+  if (notificationData?.type !== 'board_invitation') {
+    throw new Error('This is not a board invitation notification');
+  }
+
+  // Verify boardId matches
+  if (notificationData?.boardId !== boardId) {
+    throw new Error('Board ID does not match the invitation');
+  }
+
   const inviterId = notificationData?.actorId;
 
   // Get user data to get display name
@@ -162,14 +192,24 @@ export const acceptBoardInvitation = async (
   const userData = userSnap.data();
   const userDisplayName = userData?.displayName || 'A user';
 
-  // Get current board data to add member with viewer role
+  // Get current board data
   const boardSnap = await getDoc(boardRef);
+  if (!boardSnap.exists()) {
+    throw new Error('Board not found');
+  }
   const boardData = boardSnap.data();
   const currentMembers = boardData?.members || {};
+  const currentMemberIds = boardData?.memberIds || [];
+
+  // Check if user is already a member
+  if (userId in currentMembers) {
+    throw new Error('User is already a member of this board');
+  }
 
   // Add user to board members with viewer role
   await updateDoc(boardRef, {
     members: { ...currentMembers, [userId]: 'viewer' as Role },
+    memberIds: [...currentMemberIds, userId],
     updatedAt: serverTimestamp(),
   });
 
@@ -235,43 +275,45 @@ export const listenToNotifications = (
 ) => {
   const notificationsCol = collection(db, 'notifications');
   const q = query(notificationsCol, where('userId', '==', userId), orderBy('createdAt', 'desc'));
-  return onSnapshot(q, (snapshot) => {
-    const notifications = snapshot.docs.map((doc) => {
-      const createdAt = parseTimestamp(doc.data()?.createdAt);
-      return { id: doc.id, ...doc.data(), createdAt } as AppNotification;
-    });
-    callback(notifications);
-  });
+  return onSnapshot(
+    q,
+    (snapshot) => {
+      const notifications = snapshot.docs.map((doc) => {
+        const createdAt = parseTimestamp(doc.data()?.createdAt);
+        return { id: doc.id, ...doc.data(), createdAt } as AppNotification;
+      });
+      callback(notifications);
+    },
+    (error) => {
+      console.error(`[Firestore] Failed to listen to notifications for user "${userId}":`, error);
+    }
+  );
 };
 
 // BOARD OPERATIONS
 
 // Create Board
 export const addBoard = async (values: Omit<Board, 'id' | 'createdAt' | 'updatedAt'>) => {
+  const memberIds = Object.keys(values.members);
+
+  // Filter out undefined values
+  const filteredValues = Object.entries(values).reduce(
+    (acc, [key, value]) => {
+      if (value !== undefined) {
+        acc[key] = value;
+      }
+      return acc;
+    },
+    {} as Record<string, unknown>
+  );
+
   const docRef = await addDoc(boardsCol, {
-    ...values,
+    ...filteredValues,
+    memberIds,
     createdAt: serverTimestamp(),
     updatedAt: serverTimestamp(),
   });
   return docRef.id;
-};
-
-// Helper: Add member to board with specific role
-export const addBoardMember = async (boardId: string, userId: string, role: Role) => {
-  const boardRef = doc(db, 'boards', boardId);
-  const boardSnap = await getDoc(boardRef);
-  const boardData = boardSnap.data();
-  const currentMembers = boardData?.members || {};
-
-  // Check if user is already a member
-  if (userId in currentMembers) {
-    throw new Error('User is already a member of this board');
-  }
-
-  await updateDoc(boardRef, {
-    members: { ...currentMembers, [userId]: role },
-    updatedAt: serverTimestamp(),
-  });
 };
 
 // Helper: Remove member from board
@@ -280,11 +322,14 @@ export const removeBoardMember = async (boardId: string, userId: string) => {
   const boardSnap = await getDoc(boardRef);
   const boardData = boardSnap.data();
   const currentMembers = boardData?.members || {};
+  const currentMemberIds = boardData?.memberIds || [];
 
-  const { [userId]: removed, ...remainingMembers } = currentMembers;
+  const { [userId]: _removed, ...remainingMembers } = currentMembers;
+  const remainingMemberIds = currentMemberIds.filter((id: string) => id !== userId);
 
   await updateDoc(boardRef, {
     members: remainingMembers,
+    memberIds: remainingMemberIds,
     updatedAt: serverTimestamp(),
   });
 };
@@ -306,21 +351,40 @@ export const updateBoardMemberRole = async (boardId: string, userId: string, new
   });
 };
 
-// Helper: Get user's role on a board
-export const getUserBoardRole = async (boardId: string, userId: string): Promise<Role | null> => {
-  const boardRef = doc(db, 'boards', boardId);
-  const boardSnap = await getDoc(boardRef);
-  const boardData = boardSnap.data();
-  const members = boardData?.members || {};
-
-  return members[userId] || null;
-};
-
 // Update Board
-export const updateBoard = async (boardId: string, updates: Partial<Omit<Board, 'id'>>) => {
+export const updateBoard = async (
+  boardId: string,
+  updates: Partial<Omit<Board, 'id'>>,
+  userId: string
+) => {
   const boardRef = doc(db, 'boards', boardId);
+
+  // Get board data for validation
+  const boardSnap = await getDoc(boardRef);
+  if (!boardSnap.exists()) {
+    throw new Error('Board not found');
+  }
+  const boardData = boardSnap.data();
+
+  // Client-side validation: Check if user is owner or admin
+  const userRole = boardData?.members?.[userId];
+  if (boardData?.ownerId !== userId && userRole !== 'admin') {
+    throw new Error('User does not have permission to update this board');
+  }
+
+  // Filter out undefined values
+  const filteredUpdates = Object.entries(updates).reduce(
+    (acc, [key, value]) => {
+      if (value !== undefined) {
+        acc[key] = value;
+      }
+      return acc;
+    },
+    {} as Record<string, unknown>
+  );
+
   return await updateDoc(boardRef, {
-    ...updates,
+    ...filteredUpdates,
     updatedAt: serverTimestamp(),
   });
 };
@@ -331,34 +395,94 @@ export const deleteBoard = async (boardId: string) => {
   return await deleteDoc(boardRef);
 };
 
-// Get Boards (Real-time listener)
-export const listenToBoards = (callback: (boards: Board[]) => void) => {
-  const q = query(boardsCol, orderBy('createdAt', 'asc'));
-  return onSnapshot(q, (snapshot) => {
-    const boards = snapshot.docs.map((doc) => {
-      const createdAt = parseTimestamp(doc.data()?.createdAt);
-      const updatedAt = parseTimestamp(doc.data()?.updatedAt);
-      return { id: doc.id, ...doc.data(), createdAt, updatedAt } as Board;
-    });
-    callback(boards);
-  });
-};
-
 // Listen to user's boards (either as owner or member)
 export const listenToUserBoards = (userId: string, callback: (boards: Board[]) => void) => {
-  const q = query(boardsCol, orderBy('createdAt', 'desc'));
-  return onSnapshot(q, (snapshot) => {
-    const allBoards = snapshot.docs.map((doc) => {
-      const createdAt = parseTimestamp(doc.data()?.createdAt) || new Date();
-      const updatedAt = parseTimestamp(doc.data()?.updatedAt) || new Date();
-      return { id: doc.id, ...doc.data(), createdAt, updatedAt } as Board;
-    });
+  // Query boards where user is owner
+  const ownerQuery = query(boardsCol, where('ownerId', '==', userId), orderBy('createdAt', 'desc'));
 
-    // Filter boards where user is owner or a member
-    const userBoards = allBoards.filter(
-      (board) => board.ownerId === userId || userId in board.members
-    );
+  // Query boards where user is in memberIds array
+  const memberQuery = query(
+    boardsCol,
+    where('memberIds', 'array-contains', userId),
+    orderBy('createdAt', 'desc')
+  );
 
-    callback(userBoards);
-  });
+  let ownerBoards: Board[] = [];
+  let memberBoards: Board[] = [];
+  let ownerLoaded = false;
+  let memberLoaded = false;
+
+  const unsubscribeOwner = onSnapshot(
+    ownerQuery,
+    (snapshot) => {
+      ownerBoards = snapshot.docs.map((doc) => {
+        const createdAt = parseTimestamp(doc.data()?.createdAt) || new Date();
+        const updatedAt = parseTimestamp(doc.data()?.updatedAt) || new Date();
+        return { id: doc.id, ...doc.data(), createdAt, updatedAt } as Board;
+      });
+      ownerLoaded = true;
+
+      if (ownerLoaded && memberLoaded) {
+        // Merge and deduplicate boards
+        const boardMap = new Map<string, Board>();
+        [...ownerBoards, ...memberBoards].forEach((board) => {
+          boardMap.set(board.id, board);
+        });
+
+        // Client-side validation: Filter boards to ensure user is owner or in memberIds
+        const filteredBoards = Array.from(boardMap.values()).filter(
+          (board) => board.ownerId === userId || board.memberIds?.includes(userId)
+        );
+
+        callback(
+          filteredBoards.sort(
+            (a, b) => (b.createdAt?.getTime() || 0) - (a.createdAt?.getTime() || 0)
+          )
+        );
+      }
+    },
+    (error) => {
+      console.error(`[Firestore] Failed to listen to owned boards for user "${userId}":`, error);
+    }
+  );
+
+  const unsubscribeMember = onSnapshot(
+    memberQuery,
+    (snapshot) => {
+      memberBoards = snapshot.docs.map((doc) => {
+        const createdAt = parseTimestamp(doc.data()?.createdAt) || new Date();
+        const updatedAt = parseTimestamp(doc.data()?.updatedAt) || new Date();
+        return { id: doc.id, ...doc.data(), createdAt, updatedAt } as Board;
+      });
+      memberLoaded = true;
+
+      if (ownerLoaded && memberLoaded) {
+        // Merge and deduplicate boards
+        const boardMap = new Map<string, Board>();
+        [...ownerBoards, ...memberBoards].forEach((board) => {
+          boardMap.set(board.id, board);
+        });
+
+        // Client-side validation: Filter boards to ensure user is owner or in memberIds
+        const filteredBoards = Array.from(boardMap.values()).filter(
+          (board) => board.ownerId === userId || board.memberIds?.includes(userId)
+        );
+
+        callback(
+          filteredBoards.sort(
+            (a, b) => (b.createdAt?.getTime() || 0) - (a.createdAt?.getTime() || 0)
+          )
+        );
+      }
+    },
+    (error) => {
+      console.error(`[Firestore] Failed to listen to member boards for user "${userId}":`, error);
+    }
+  );
+
+  // Return combined unsubscribe function
+  return () => {
+    unsubscribeOwner();
+    unsubscribeMember();
+  };
 };

--- a/src/store/useBoards.ts
+++ b/src/store/useBoards.ts
@@ -56,14 +56,17 @@ export function useBoards(): BoardsState {
   );
 
   // Update an existing board
-  const updateBoard = useCallback(async (id: string, updates: Partial<Omit<Board, 'id'>>) => {
-    try {
-      await updateBoardInFirestore(id, updates);
-    } catch (error) {
-      console.error('Error updating board:', error);
-      throw error;
-    }
-  }, []);
+  const updateBoard = useCallback(
+    async (id: string, updates: Partial<Omit<Board, 'id'>>, userId: string) => {
+      try {
+        await updateBoardInFirestore(id, updates, userId);
+      } catch (error) {
+        console.error('Error updating board:', error);
+        throw error;
+      }
+    },
+    []
+  );
 
   // Delete a board
   const deleteBoard = useCallback(async (id: string) => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -124,6 +124,7 @@ export interface Board {
   updatedAt: TimestampLike;
   ownerId: string;
   members: Record<string, Role>; // Map of userId -> role
+  memberIds?: string[]; // Array of member IDs for indexed queries (computed from members)
 }
 
 export interface BoardsState {
@@ -131,6 +132,6 @@ export interface BoardsState {
   loading: boolean;
   initListener: () => () => void;
   createBoard: (data: Omit<Board, 'id' | 'createdAt' | 'updatedAt'>) => Promise<string>;
-  updateBoard: (id: string, updates: Partial<Omit<Board, 'id'>>) => Promise<void>;
+  updateBoard: (id: string, updates: Partial<Omit<Board, 'id'>>, userId: string) => Promise<void>;
   deleteBoard: (id: string) => Promise<void>;
 }


### PR DESCRIPTION
…admins

Implement role change controls allowing admins and owners to modify member roles (admin/editor/viewer) via dropdown menu in member list. Add member removal capability with confirmation dialog. Update Firestore security rules to allow authenticated users to read all boards and list notifications. Move notification listener initialization from KanbanBoard to Navbar component. Add automatic board navigation after accepting invitations. Include permission checks to restrict management